### PR TITLE
Fix signature error on FT_Glyph_Get_CBox causing memory access error

### DIFF
--- a/SharpFont/FT.Internal.cs
+++ b/SharpFont/FT.Internal.cs
@@ -28,6 +28,7 @@ using System.Runtime.InteropServices;
 using SharpFont.Cache;
 using SharpFont.PostScript;
 using SharpFont.TrueType;
+using SharpFont.Internal;
 
 namespace SharpFont
 {
@@ -188,7 +189,7 @@ namespace SharpFont
 		internal static extern Error FT_Glyph_Transform(IntPtr glyph, ref FTMatrix matrix, ref FTVector delta);
 
 		[DllImport(FreetypeDll, CallingConvention = CallConvention)]
-		internal static extern void FT_Glyph_Get_CBox(IntPtr glyph, GlyphBBoxMode bbox_mode, out IntPtr acbox);
+		internal static extern void FT_Glyph_Get_CBox(IntPtr glyph, GlyphBBoxMode bbox_mode, ref BBoxRec acbox);
 
 		[DllImport(FreetypeDll, CallingConvention = CallConvention)]
 		internal static extern Error FT_Glyph_To_Bitmap(ref IntPtr the_glyph, RenderMode render_mode, ref FTVector origin, [MarshalAs(UnmanagedType.U1)] bool destroy);

--- a/SharpFont/Glyph.cs
+++ b/SharpFont/Glyph.cs
@@ -244,10 +244,10 @@ namespace SharpFont
 			if (disposed)
 				throw new ObjectDisposedException("Glyph", "Cannot access a disposed object.");
 
-			IntPtr cboxRef;
-			FT.FT_Glyph_Get_CBox(Reference, mode, out cboxRef);
+			BBoxRec box = new BBoxRec();
+			FT.FT_Glyph_Get_CBox(Reference, mode, ref box);
 
-			return new BBox(cboxRef);
+			return new BBox(box);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Hi,

I've tried to use Glyph.GetCBox() and I had a memory access error.
While looking at SharpFont code I saw that there was an error on FT_Glyph_Get_CBox definition (see http://www.freetype.org/freetype2/docs/reference/ft2-glyph_management.html#FT_Glyph_Get_CBox).
I've fixed it and now it works !
