### PR TITLE
Increment penX instead of width by kerning when drawing string

### DIFF
--- a/Examples/Program.cs
+++ b/Examples/Program.cs
@@ -145,7 +145,7 @@ namespace Examples
 				if (face.HasKerning && i < text.Length - 1)
 				{
 					char cNext = text[i + 1];
-					width += (int)face.GetKerning(glyphIndex, face.GetCharIndex(cNext), KerningMode.Default).X >> 6;
+					penX += (int)face.GetKerning(glyphIndex, face.GetCharIndex(cNext), KerningMode.Default).X >> 6;
 				}
 			}
 


### PR DESCRIPTION
A copy/paste mistake I just noticed.

I haven't checked, but I'm fairly certain that the original example throws if there's negative kerning.
