### PR TITLE
Fixed issue with filename case sensitivity.

### DIFF
--- a/SharpFont/SharpFont.csproj
+++ b/SharpFont/SharpFont.csproj
@@ -184,7 +184,7 @@
     <Compile Include="TrueTypeValidationFlags.cs" />
     <Compile Include="TrueType\Internal\SfntNameRec.cs" />
     <Compile Include="TrueType\SfntName.cs" />
-    <Compile Include="TrueType\EncodingId.cs" />
+    <Compile Include="TrueType\EncodingID.cs" />
     <Compile Include="Error.cs" />
     <Compile Include="Face.cs" />
     <Compile Include="FaceFlags.cs" />
@@ -223,8 +223,8 @@
     <Compile Include="TrueType\Internal\VertHeaderRec.cs" />
     <Compile Include="TrueType\MaxProfile.cs" />
     <Compile Include="TrueType\OS2.cs" />
-    <Compile Include="TrueType\Pclt.cs" />
-    <Compile Include="TrueType\PlatformId.cs" />
+    <Compile Include="TrueType\PCLT.cs" />
+    <Compile Include="TrueType\PlatformID.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PostScript\DictionaryKeys.cs" />
     <Compile Include="RenderMode.cs" />


### PR DESCRIPTION
If I try to build with xbuild in my Arch linux, I get following error:

```
~/dev/SharpFont> xbuild

----build stuff scissored out----

Build FAILED.
Errors:

/home/lazzu/dev/SharpFont/SharpFont.sln (default targets) ->
(Build target) ->
/home/lazzu/dev/SharpFont/SharpFont/SharpFont.csproj (default targets) ->
/usr/lib/mono/4.0/Microsoft.CSharp.targets (CoreCompile target) ->

    : error CS2001: Source file `TrueType/EncodingId.cs' could not be found
    : error CS2001: Source file `TrueType/Pclt.cs' could not be found
    : error CS2001: Source file `TrueType/PlatformId.cs' could not be found

     0 Warning(s)
     3 Error(s)

Time Elapsed 00:00:00.5918730
```

The reason is in case sensitivity. I have fixed that in this commit.
