### PR TITLE
Removed the dependency on XQuartz

### DIFF
--- a/Source/SharpFont/SharpFont.dll.config
+++ b/Source/SharpFont/SharpFont.dll.config
@@ -2,6 +2,6 @@
 <configuration>
 	<dllmap dll="freetype6.dll">
 		<dllentry os="linux" dll="libfreetype.so.6" />
-		<dllentry os="osx" dll="/usr/X11/lib/libfreetype.6.dylib" />
+		<dllentry os="osx" dll="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
 	</dllmap>
 </configuration>


### PR DESCRIPTION
We removed the dependency on X11 on Mac OpenRA/OpenRA#5244 due to inconveniences such as long font-caching delays https://github.com/OpenRA/OpenRA/issues/4785 and an unnecessary extra dependency that is not shipped by Apple anymore.

See also https://github.com/OpenRA/OpenRA/pull/7915.