### PR TITLE
issues of building on case-senstive file system.

### DIFF
--- a/Source/SharpFont/SharpFont.csproj
+++ b/Source/SharpFont/SharpFont.csproj
@@ -164,7 +164,7 @@
     <Compile Include="TrueTypeValidationFlags.cs" />
     <Compile Include="TrueType\Internal\SfntNameRec.cs" />
     <Compile Include="TrueType\SfntName.cs" />
-    <Compile Include="TrueType\EncodingID.cs" />
+    <Compile Include="TrueType\EncodingId.cs" />
     <Compile Include="Error.cs" />
     <Compile Include="Face.cs" />
     <Compile Include="FaceFlags.cs" />
@@ -203,8 +203,8 @@
     <Compile Include="TrueType\Internal\VertHeaderRec.cs" />
     <Compile Include="TrueType\MaxProfile.cs" />
     <Compile Include="TrueType\OS2.cs" />
-    <Compile Include="TrueType\PCLT.cs" />
-    <Compile Include="TrueType\PlatformID.cs" />
+    <Compile Include="TrueType\Pclt.cs" />
+    <Compile Include="TrueType\PlatformId.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PostScript\DictionaryKeys.cs" />
     <Compile Include="RenderMode.cs" />

--- a/Source/SharpFont/SharpFont.csproj
+++ b/Source/SharpFont/SharpFont.csproj
@@ -21,7 +21,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\SharpFont.XML</DocumentationFile>
+    <DocumentationFile>bin\Debug\SharpFont.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>


### PR DESCRIPTION
A few issues with building on case-sensitive file system. Should be obvious why the changes are made. No effect on building on non-senstive file system (i.e. windows) or case-sensitive-but-not-case-preserving file system (i.e. Mac OS X).