### PR TITLE
Add file dialog result to listbox.

### DIFF
--- a/Source/Examples/ExampleForm.Designer.cs
+++ b/Source/Examples/ExampleForm.Designer.cs
@@ -205,7 +205,7 @@
 			this.pictureBoxText.Size = new System.Drawing.Size(326, 288);
 			this.pictureBoxText.TabIndex = 0;
 			this.pictureBoxText.TabStop = false;
-			this.pictureBoxText.Paint += new System.Windows.Forms.PaintEventHandler(this.pictureBoxText_Paint);
+			//this.pictureBoxText.Paint += new System.Windows.Forms.PaintEventHandler(this.pictureBoxText_Paint);
 			// 
 			// listBoxFont
 			// 

--- a/Source/Examples/ExampleForm.cs
+++ b/Source/Examples/ExampleForm.cs
@@ -85,7 +85,10 @@ namespace Examples
 
 		private void mainMenuFileOpen_Click(object sender, EventArgs e)
 		{
-			openFontDialog.ShowDialog();
+			if(openFontDialog.ShowDialog() == DialogResult.OK)
+				{
+					listBoxFont.Items.Add(openFontDialog.FileName);
+				}
 		}
 
 		private void mainMenuFileExit_Click(object sender, EventArgs e)

--- a/Source/Examples/ExampleForm.cs
+++ b/Source/Examples/ExampleForm.cs
@@ -64,6 +64,9 @@ namespace Examples
 
 		private void RebuildFontList()
 		{
+			if ( !Directory.Exists(fontFolder) )
+				return;
+
 			//HACK only checking for ttf even though FreeType supports far more formats.
 			foreach (var file in Directory.GetFiles(fontFolder, "*.ttf"))
 				listBoxFont.Items.Add(Path.GetFileName(file));

--- a/Source/Examples/ExampleForm.cs
+++ b/Source/Examples/ExampleForm.cs
@@ -84,6 +84,7 @@ namespace Examples
 			fontFace = new Face(lib, Path.Combine(Path.GetFullPath(fontFolder), (string)listBoxFont.SelectedItem));
 			fontFace.SetCharSize(0, 62, 0, 96);
 			pictureBoxText.Invalidate();
+			pictureBoxText.Image = Program.RenderString(lib, fontFace, sampleText);
 		}
 
 		private void mainMenuFileOpen_Click(object sender, EventArgs e)

--- a/Source/Examples/Program.cs
+++ b/Source/Examples/Program.cs
@@ -93,6 +93,9 @@ namespace Examples
 
 			height = top + bottom;
 
+			if (width == 0 || height == 0)
+				return null;
+
 			//create a new bitmap that fits the string.
 			Bitmap bmp = new Bitmap((int)Math.Ceiling(width), (int)Math.Ceiling(height));
 			Graphics g = Graphics.FromImage(bmp);


### PR DESCRIPTION
The File->Open menu option opens a file dialog, but does nothing afterwards.
This change puts the dialog result to the list box, to make the File->Open
menu option work as intended.

fixes
https://github.com/Robmaister/SharpFont/issues/69