### PR TITLE
Library

### DIFF
--- a/Source/SharpFont/FTBitmap.cs
+++ b/Source/SharpFont/FTBitmap.cs
@@ -430,8 +430,9 @@ namespace SharpFont
 					ColorPalette palette = bmp.Palette;
 					for (int i = 0; i < palette.Entries.Length; i++)
 					{
+						// convert 8-bit range to 4-bit: (2^8-1) / (2^4-1) = 255 / 15 = 17, gives 16 values which are 0,17,34..255
 						float a = (i * 17) / 255f;
-						palette.Entries[i] = Color.FromArgb(i * 17, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
+						palette.Entries[i] = Color.FromArgb(i * 17, (int)(color.R), (int)(color.G), (int)(color.B));
 					}
 
 					bmp.Palette = palette;
@@ -452,7 +453,7 @@ namespace SharpFont
 					for (int i = 0; i < palette.Entries.Length; i++)
 					{
 						float a = i / 255f;
-						palette.Entries[i] = Color.FromArgb(i, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
+						palette.Entries[i] = Color.FromArgb(i, (int)(color.R), (int)(color.G), (int)(color.B));
 					}
 
 					//HACK There's a bug in Mono's libgdiplus requiring the "PaletteHasAlpha" flag to be set for transparency to work properly

--- a/Source/SharpFont/FTBitmap.cs
+++ b/Source/SharpFont/FTBitmap.cs
@@ -102,7 +102,7 @@ namespace SharpFont
 		#endregion
 
 		#region Properties
-		
+
 		/// <summary>
 		/// Gets a value indicating whether the <see cref="FTBitmap"/> has been disposed.
 		/// </summary>
@@ -400,94 +400,94 @@ namespace SharpFont
 			switch (rec.pixel_mode)
 			{
 				case PixelMode.Mono:
-				{
-					Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format1bppIndexed);
-					var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format1bppIndexed);
+					{
+						Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format1bppIndexed);
+						var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format1bppIndexed);
 
-					for (int i = 0; i < rec.rows; i++)
-						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+						for (int i = 0; i < rec.rows; i++)
+							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
 
-					bmp.UnlockBits(locked);
+						bmp.UnlockBits(locked);
 
-					ColorPalette palette = bmp.Palette;
-					palette.Entries[0] = Color.FromArgb(0, color);
-					palette.Entries[1] = Color.FromArgb(255, color);
+						ColorPalette palette = bmp.Palette;
+						palette.Entries[0] = Color.FromArgb(0, color);
+						palette.Entries[1] = Color.FromArgb(255, color);
 
-					bmp.Palette = palette;
-					return bmp;
-				}
+						bmp.Palette = palette;
+						return bmp;
+					}
 
 				case PixelMode.Gray4:
-				{
-					Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format4bppIndexed);
-					var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format4bppIndexed);
-
-					for (int i = 0; i < rec.rows; i++)
-						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
-
-					bmp.UnlockBits(locked);
-
-					ColorPalette palette = bmp.Palette;
-					for (int i = 0; i < palette.Entries.Length; i++)
 					{
-						float a = (i * 17) / 255f;
-						palette.Entries[i] = Color.FromArgb(i * 17, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
-					}
+						Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format4bppIndexed);
+						var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format4bppIndexed);
 
-					bmp.Palette = palette;
-					return bmp;
-				}
+						for (int i = 0; i < rec.rows; i++)
+							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+
+						bmp.UnlockBits(locked);
+
+						ColorPalette palette = bmp.Palette;
+						for (int i = 0; i < palette.Entries.Length; i++)
+						{
+							float a = (i * 17) / 255f;
+							palette.Entries[i] = Color.FromArgb(i * 17, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
+						}
+
+						bmp.Palette = palette;
+						return bmp;
+					}
 
 				case PixelMode.Gray:
-				{
-					Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format8bppIndexed);
-					var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed);
-
-					for (int i = 0; i < rec.rows; i++)
-						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
-
-					bmp.UnlockBits(locked);
-
-					ColorPalette palette = bmp.Palette;
-					for (int i = 0; i < palette.Entries.Length; i++)
 					{
-						float a = i / 255f;
-						palette.Entries[i] = Color.FromArgb(i, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
-					}
+						Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format8bppIndexed);
+						var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed);
 
-					//HACK There's a bug in Mono's libgdiplus requiring the "PaletteHasAlpha" flag to be set for transparency to work properly
-					//See https://github.com/Robmaister/SharpFont/issues/62
-					if (!hasCheckedForMono)
-					{
-						hasCheckedForMono = true;
-						isRunningOnMono = Type.GetType("Mono.Runtime") != null;
-						if (isRunningOnMono)
+						for (int i = 0; i < rec.rows; i++)
+							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+
+						bmp.UnlockBits(locked);
+
+						ColorPalette palette = bmp.Palette;
+						for (int i = 0; i < palette.Entries.Length; i++)
 						{
-							monoPaletteFlagsField = typeof(ColorPalette).GetField("flags", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+							float a = i / 255f;
+							palette.Entries[i] = Color.FromArgb(i, (int)(color.R), (int)(color.G), (int)(color.B));
 						}
+
+						//HACK There's a bug in Mono's libgdiplus requiring the "PaletteHasAlpha" flag to be set for transparency to work properly
+						//See https://github.com/Robmaister/SharpFont/issues/62
+						if (!hasCheckedForMono)
+						{
+							hasCheckedForMono = true;
+							isRunningOnMono = Type.GetType("Mono.Runtime") != null;
+							if (isRunningOnMono)
+							{
+								monoPaletteFlagsField = typeof(ColorPalette).GetField("flags", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+							}
+						}
+
+						if (isRunningOnMono)
+							monoPaletteFlagsField.SetValue(palette, palette.Flags | 1);
+
+						bmp.Palette = palette;
+						return bmp;
 					}
-
-					if (isRunningOnMono)
-						monoPaletteFlagsField.SetValue(palette, palette.Flags | 1);
-
-					bmp.Palette = palette;
-					return bmp;
-				}
 
 				case PixelMode.Lcd:
-				{
-					//TODO apply color
-					int bmpWidth = rec.width / 3;
-					Bitmap bmp = new Bitmap(bmpWidth, rec.rows, PixelFormat.Format24bppRgb);
-					var locked = bmp.LockBits(new Rectangle(0, 0, bmpWidth, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
+					{
+						//TODO apply color
+						int bmpWidth = rec.width / 3;
+						Bitmap bmp = new Bitmap(bmpWidth, rec.rows, PixelFormat.Format24bppRgb);
+						var locked = bmp.LockBits(new Rectangle(0, 0, bmpWidth, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
 
-					for (int i = 0; i < rec.rows; i++)
-						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+						for (int i = 0; i < rec.rows; i++)
+							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
 
-					bmp.UnlockBits(locked);
+						bmp.UnlockBits(locked);
 
-					return bmp;
-				}
+						return bmp;
+					}
 				/*case PixelMode.VerticalLcd:
 				{
 					int bmpHeight = rec.rows / 3;

--- a/Source/SharpFont/FTBitmap.cs
+++ b/Source/SharpFont/FTBitmap.cs
@@ -102,7 +102,7 @@ namespace SharpFont
 		#endregion
 
 		#region Properties
-
+		
 		/// <summary>
 		/// Gets a value indicating whether the <see cref="FTBitmap"/> has been disposed.
 		/// </summary>
@@ -400,94 +400,94 @@ namespace SharpFont
 			switch (rec.pixel_mode)
 			{
 				case PixelMode.Mono:
-					{
-						Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format1bppIndexed);
-						var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format1bppIndexed);
+				{
+					Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format1bppIndexed);
+					var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format1bppIndexed);
 
-						for (int i = 0; i < rec.rows; i++)
-							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+					for (int i = 0; i < rec.rows; i++)
+						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
 
-						bmp.UnlockBits(locked);
+					bmp.UnlockBits(locked);
 
-						ColorPalette palette = bmp.Palette;
-						palette.Entries[0] = Color.FromArgb(0, color);
-						palette.Entries[1] = Color.FromArgb(255, color);
+					ColorPalette palette = bmp.Palette;
+					palette.Entries[0] = Color.FromArgb(0, color);
+					palette.Entries[1] = Color.FromArgb(255, color);
 
-						bmp.Palette = palette;
-						return bmp;
-					}
+					bmp.Palette = palette;
+					return bmp;
+				}
 
 				case PixelMode.Gray4:
+				{
+					Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format4bppIndexed);
+					var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format4bppIndexed);
+
+					for (int i = 0; i < rec.rows; i++)
+						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+
+					bmp.UnlockBits(locked);
+
+					ColorPalette palette = bmp.Palette;
+					for (int i = 0; i < palette.Entries.Length; i++)
 					{
-						Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format4bppIndexed);
-						var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format4bppIndexed);
-
-						for (int i = 0; i < rec.rows; i++)
-							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
-
-						bmp.UnlockBits(locked);
-
-						ColorPalette palette = bmp.Palette;
-						for (int i = 0; i < palette.Entries.Length; i++)
-						{
-							float a = (i * 17) / 255f;
-							palette.Entries[i] = Color.FromArgb(i * 17, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
-						}
-
-						bmp.Palette = palette;
-						return bmp;
+						float a = (i * 17) / 255f;
+						palette.Entries[i] = Color.FromArgb(i * 17, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
 					}
+
+					bmp.Palette = palette;
+					return bmp;
+				}
 
 				case PixelMode.Gray:
+				{
+					Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format8bppIndexed);
+					var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed);
+
+					for (int i = 0; i < rec.rows; i++)
+						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+
+					bmp.UnlockBits(locked);
+
+					ColorPalette palette = bmp.Palette;
+					for (int i = 0; i < palette.Entries.Length; i++)
 					{
-						Bitmap bmp = new Bitmap(rec.width, rec.rows, PixelFormat.Format8bppIndexed);
-						var locked = bmp.LockBits(new Rectangle(0, 0, rec.width, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed);
-
-						for (int i = 0; i < rec.rows; i++)
-							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
-
-						bmp.UnlockBits(locked);
-
-						ColorPalette palette = bmp.Palette;
-						for (int i = 0; i < palette.Entries.Length; i++)
-						{
-							float a = i / 255f;
-							palette.Entries[i] = Color.FromArgb(i, (int)(color.R), (int)(color.G), (int)(color.B));
-						}
-
-						//HACK There's a bug in Mono's libgdiplus requiring the "PaletteHasAlpha" flag to be set for transparency to work properly
-						//See https://github.com/Robmaister/SharpFont/issues/62
-						if (!hasCheckedForMono)
-						{
-							hasCheckedForMono = true;
-							isRunningOnMono = Type.GetType("Mono.Runtime") != null;
-							if (isRunningOnMono)
-							{
-								monoPaletteFlagsField = typeof(ColorPalette).GetField("flags", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-							}
-						}
-
-						if (isRunningOnMono)
-							monoPaletteFlagsField.SetValue(palette, palette.Flags | 1);
-
-						bmp.Palette = palette;
-						return bmp;
+						float a = i / 255f;
+						palette.Entries[i] = Color.FromArgb(i, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
 					}
+
+					//HACK There's a bug in Mono's libgdiplus requiring the "PaletteHasAlpha" flag to be set for transparency to work properly
+					//See https://github.com/Robmaister/SharpFont/issues/62
+					if (!hasCheckedForMono)
+					{
+						hasCheckedForMono = true;
+						isRunningOnMono = Type.GetType("Mono.Runtime") != null;
+						if (isRunningOnMono)
+						{
+							monoPaletteFlagsField = typeof(ColorPalette).GetField("flags", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+						}
+					}
+
+					if (isRunningOnMono)
+						monoPaletteFlagsField.SetValue(palette, palette.Flags | 1);
+
+					bmp.Palette = palette;
+					return bmp;
+				}
 
 				case PixelMode.Lcd:
-					{
-						//TODO apply color
-						int bmpWidth = rec.width / 3;
-						Bitmap bmp = new Bitmap(bmpWidth, rec.rows, PixelFormat.Format24bppRgb);
-						var locked = bmp.LockBits(new Rectangle(0, 0, bmpWidth, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
+				{
+					//TODO apply color
+					int bmpWidth = rec.width / 3;
+					Bitmap bmp = new Bitmap(bmpWidth, rec.rows, PixelFormat.Format24bppRgb);
+					var locked = bmp.LockBits(new Rectangle(0, 0, bmpWidth, rec.rows), ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
 
-						for (int i = 0; i < rec.rows; i++)
-							PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
+					for (int i = 0; i < rec.rows; i++)
+						PInvokeHelper.Copy(Buffer, i * rec.pitch, locked.Scan0, i * locked.Stride, locked.Stride);
 
-						bmp.UnlockBits(locked);
+					bmp.UnlockBits(locked);
 
-						return bmp;
-					}
+					return bmp;
+				}
 				/*case PixelMode.VerticalLcd:
 				{
 					int bmpHeight = rec.rows / 3;


### PR DESCRIPTION
I managed to keep whitespace changes out of one of these but not the other. I'm not sure how to fix it at this point.
In FTBitmap, the only change is in line 455.... instead of multiplying each channel by a (R,G,B), only alpha is affected by i. So the original color is preserved throughout the palette values. Otherwise, it seems to be an odd sort of mask that goes from black to the original color and I couldn't figure out any kind of mask or blend scheme that would work with an arbitrary input color (this is easier to test, now that the example provides a way to change colors).
