### PR TITLE
Fix SharpFont.dll.config to work with debian packaging

### DIFF
--- a/Source/SharpFont/SharpFont.dll.config
+++ b/Source/SharpFont/SharpFont.dll.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-	<dllmap dll="freetype6.dll">
-		<dllentry os="linux" dll="libfreetype.so.6" />
-		<dllentry os="osx" dll="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
-	</dllmap>
+	<dllmap dll="freetype6.dll" os="linux" target="libfreetype.so.6" />
+	<dllmap dll="freetype6.dll" os="osx" target="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
 </configuration>


### PR DESCRIPTION
The old version appears to work at runtime, but it fails badly when
trying to build a debian package that uses SharpFont.  As far as I
can tell, this new version conforms better with the description of
DllMaps at http://www.mono-project.com/docs/advanced/pinvoke/dllmap/.