### PR TITLE
Fix for issue #77 - Loading Sfnt tables

### DIFF
--- a/Source/SharpFont/TrueType/Internal/HeaderRec.cs
+++ b/Source/SharpFont/TrueType/Internal/HeaderRec.cs
@@ -42,10 +42,10 @@ namespace SharpFont.TrueType.Internal
 		internal ushort Flags;
 		internal ushort Units_Per_EM;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 2)]
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
 		internal FT_Long[] Created;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 2)]
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
 		internal FT_Long[] Modified;
 
 		internal short xMin;

--- a/Source/SharpFont/TrueType/Internal/HoriHeaderRec.cs
+++ b/Source/SharpFont/TrueType/Internal/HoriHeaderRec.cs
@@ -47,7 +47,7 @@ namespace SharpFont.TrueType.Internal
 		internal short caret_Slope_Run;
 		internal short caret_Offset;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 4)]
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
 		internal short[] Reserved;
 
 		internal short metric_Data_Format;

--- a/Source/SharpFont/TrueType/Internal/OS2Rec.cs
+++ b/Source/SharpFont/TrueType/Internal/OS2Rec.cs
@@ -50,7 +50,7 @@ namespace SharpFont.TrueType.Internal
 		internal short yStrikeoutPosition;
 		internal short sFamilyClass;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 10)]
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
 		internal byte[] panose;
 
 		internal FT_ULong ulUnicodeRange1;
@@ -58,7 +58,7 @@ namespace SharpFont.TrueType.Internal
 		internal FT_ULong ulUnicodeRange3;
 		internal FT_ULong ulUnicodeRange4;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 4)]
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
 		internal byte[] achVendID;
 
 		internal ushort fsSelection;

--- a/Source/SharpFont/TrueType/Internal/PCLTRec.cs
+++ b/Source/SharpFont/TrueType/Internal/PCLTRec.cs
@@ -45,10 +45,10 @@ namespace SharpFont.TrueType.Internal
 		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
 		internal string TypeFace;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 8)]
+		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 8)]
 		internal byte[] CharacterComplement;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 6)]
+		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 6)]
 		internal byte[] FileName;
 
 		internal byte StrokeWeight;

--- a/Source/SharpFont/TrueType/Internal/VertHeaderRec.cs
+++ b/Source/SharpFont/TrueType/Internal/VertHeaderRec.cs
@@ -47,7 +47,7 @@ namespace SharpFont.TrueType.Internal
 		internal short caret_Slope_Run;
 		internal short caret_Offset;
 
-		[MarshalAs(UnmanagedType.LPArray, SizeConst = 4)]
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
 		internal short[] Reserved;
 
 		internal short metric_Data_Format;


### PR DESCRIPTION
This fixes #77 by using ByValArray for structure fields, instead of LPArray.