### PR TITLE
If FreeType fails to open a font and assign a reference (such as for …

### DIFF
--- a/Source/SharpFontShared/FTBitmap.cs
+++ b/Source/SharpFontShared/FTBitmap.cs
@@ -530,11 +530,7 @@ namespace SharpFont
 
 				if (user)
 				{
-					Error err = FT.FT_Bitmap_Done(library.Reference, reference);
-
-					if (err != Error.Ok)
-						throw new FreeTypeException(err);
-
+					FT.FT_Bitmap_Done(library.Reference, reference);
 					Marshal.FreeHGlobal(reference);
 				}
 

--- a/Source/SharpFontShared/FTSize.cs
+++ b/Source/SharpFontShared/FTSize.cs
@@ -246,10 +246,7 @@ namespace SharpFont
 				//only dispose the user allocated sizes that are not duplicates.
 				if (userAlloc && !duplicate)
 				{
-					Error err = FT.FT_Done_Size(reference);
-
-					if (err != Error.Ok)
-						throw new FreeTypeException(err);
+					FT.FT_Done_Size(reference);
 				}
 
 				// removes itself from the parent Face, with a check to prevent this from happening when Face is

--- a/Source/SharpFontShared/Face.cs
+++ b/Source/SharpFontShared/Face.cs
@@ -47,6 +47,7 @@ namespace SharpFont
 		private FaceRec rec;
 
 		private bool disposed;
+		private bool validReference;
 
 		private GCHandle memoryFaceHandle;
 
@@ -83,6 +84,7 @@ namespace SharpFont
 				throw new FreeTypeException(err);
 
 			Reference = reference;
+			validReference = true;
 		}
 
 		//TODO make an overload with a FileStream instead of a byte[]
@@ -104,6 +106,7 @@ namespace SharpFont
 				throw new FreeTypeException(err);
 
 			Reference = reference;
+			validReference = true;
 		}
 
 		/// <summary>
@@ -123,6 +126,7 @@ namespace SharpFont
 				throw new FreeTypeException(err);
 
 			Reference = reference;
+			validReference = true;
 		}
 
 		/// <summary>
@@ -134,6 +138,7 @@ namespace SharpFont
 			: this(parent)
 		{
 			Reference = reference;
+			validReference = true;
 		}
 
 		private Face(Library parent): base(IntPtr.Zero)
@@ -2387,16 +2392,21 @@ namespace SharpFont
 
 				childSizes.Clear();
 
-				Error err = FT.FT_Done_Face(base.Reference);
+				if (validReference)
+				{
 
-				if (err != Error.Ok)
-					throw new FreeTypeException(err);
+					Error err = FT.FT_Done_Face(base.Reference);
 
-				// removes itself from the parent Library, with a check to prevent this from happening when Library is
-				// being disposed (Library disposes all it's children with a foreach loop, this causes an
-				// InvalidOperationException for modifying a collection during enumeration)
-				if (!parentLibrary.IsDisposed)
-					parentLibrary.RemoveChildFace(this);
+					if (err != Error.Ok)
+						throw new FreeTypeException(err);
+
+					// removes itself from the parent Library, with a check to prevent this from happening when Library is
+					// being disposed (Library disposes all it's children with a foreach loop, this causes an
+					// InvalidOperationException for modifying a collection during enumeration)
+					if (!parentLibrary.IsDisposed)
+						parentLibrary.RemoveChildFace(this);
+
+				}
 
 				base.Reference = IntPtr.Zero;
 				rec = new FaceRec();

--- a/Source/SharpFontShared/Face.cs
+++ b/Source/SharpFontShared/Face.cs
@@ -47,7 +47,6 @@ namespace SharpFont
 		private FaceRec rec;
 
 		private bool disposed;
-		private bool validReference;
 
 		private GCHandle memoryFaceHandle;
 
@@ -84,7 +83,6 @@ namespace SharpFont
 				throw new FreeTypeException(err);
 
 			Reference = reference;
-			validReference = true;
 		}
 
 		//TODO make an overload with a FileStream instead of a byte[]
@@ -106,7 +104,6 @@ namespace SharpFont
 				throw new FreeTypeException(err);
 
 			Reference = reference;
-			validReference = true;
 		}
 
 		/// <summary>
@@ -126,7 +123,6 @@ namespace SharpFont
 				throw new FreeTypeException(err);
 
 			Reference = reference;
-			validReference = true;
 		}
 
 		/// <summary>
@@ -138,7 +134,6 @@ namespace SharpFont
 			: this(parent)
 		{
 			Reference = reference;
-			validReference = true;
 		}
 
 		private Face(Library parent): base(IntPtr.Zero)
@@ -2392,21 +2387,16 @@ namespace SharpFont
 
 				childSizes.Clear();
 
-				if (validReference)
-				{
+				Error err = FT.FT_Done_Face(base.Reference);
 
-					Error err = FT.FT_Done_Face(base.Reference);
+				if (err != Error.Ok)
+					throw new FreeTypeException(err);
 
-					if (err != Error.Ok)
-						throw new FreeTypeException(err);
-
-					// removes itself from the parent Library, with a check to prevent this from happening when Library is
-					// being disposed (Library disposes all it's children with a foreach loop, this causes an
-					// InvalidOperationException for modifying a collection during enumeration)
-					if (!parentLibrary.IsDisposed)
-						parentLibrary.RemoveChildFace(this);
-
-				}
+				// removes itself from the parent Library, with a check to prevent this from happening when Library is
+				// being disposed (Library disposes all it's children with a foreach loop, this causes an
+				// InvalidOperationException for modifying a collection during enumeration)
+				if (!parentLibrary.IsDisposed)
+					parentLibrary.RemoveChildFace(this);
 
 				base.Reference = IntPtr.Zero;
 				rec = new FaceRec();

--- a/Source/SharpFontShared/Face.cs
+++ b/Source/SharpFontShared/Face.cs
@@ -2387,10 +2387,7 @@ namespace SharpFont
 
 				childSizes.Clear();
 
-				Error err = FT.FT_Done_Face(base.Reference);
-
-				if (err != Error.Ok)
-					throw new FreeTypeException(err);
+				FT.FT_Done_Face(base.Reference);
 
 				// removes itself from the parent Library, with a check to prevent this from happening when Library is
 				// being disposed (Library disposes all it's children with a foreach loop, this causes an

--- a/Source/SharpFontShared/Library.cs
+++ b/Source/SharpFontShared/Library.cs
@@ -871,10 +871,6 @@ namespace SharpFont
 				childManagers.Clear();
 
 				Error err = customMemory ? FT.FT_Done_Library(reference) : FT.FT_Done_FreeType(reference);
-
-				if (err != Error.Ok)
-					throw new FreeTypeException(err);
-
 				reference = IntPtr.Zero;
 			}
 		}

--- a/Source/SharpFontShared/Outline.cs
+++ b/Source/SharpFontShared/Outline.cs
@@ -620,7 +620,7 @@ namespace SharpFont
 		}
 
 		/// <summary><para>
-		/// This function analyzes a glyph outline and tries to compute its fill orientation (see 
+		/// This function analyzes a glyph outline and tries to compute its fill orientation (see
 		/// <see cref="Orientation"/>). This is done by computing the direction of each global horizontal and/or
 		/// vertical extrema within the outline.
 		/// </para><para>
@@ -676,14 +676,10 @@ namespace SharpFont
 
 				if (!duplicate)
 				{
-					Error err;
 					if (parentLibrary != null)
-						err = FT.FT_Outline_Done(parentLibrary.Reference, reference);
+						FT.FT_Outline_Done(parentLibrary.Reference, reference);
 					else
-						err = FT.FT_Outline_Done_Internal(parentMemory.Reference, reference);
-
-					if (err != Error.Ok)
-						throw new FreeTypeException(err);
+						FT.FT_Outline_Done_Internal(parentMemory.Reference, reference);
 
 					// removes itself from the parent Library, with a check to prevent this from happening when Library is
 					// being disposed (Library disposes all it's children with a foreach loop, this causes an


### PR DESCRIPTION
…a bad font file), we should not try to release the non-existing reference when disposing the face.

On a related topic... perhaps Dispose() should not be throwing exceptions?
https://msdn.microsoft.com/en-us/library/bb386039.aspx
