### PR TITLE
Added streaming support to Face

### DIFF
--- a/Source/SharpFont/FTStream.cs
+++ b/Source/SharpFont/FTStream.cs
@@ -43,14 +43,14 @@ namespace SharpFont
 	/// <returns>The number of bytes effectively read by the stream.</returns>
 	[CLSCompliant(false)]
 	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-	public delegate uint StreamIOFunc(NativeReference<FTStream> stream, uint offset, IntPtr buffer, uint count);
+	public delegate uint StreamIOFunc(IntPtr stream, uint offset, IntPtr buffer, uint count);
 
 	/// <summary>
 	/// A function used to close a given input stream.
 	/// </summary>
 	/// <param name="stream">A handle to the target stream.</param>
 	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-	public delegate void StreamCloseFunc(NativeReference<FTStream> stream);
+	public delegate void StreamCloseFunc(IntPtr stream);
 
 	/// <summary>
 	/// A handle to an input stream.
@@ -84,7 +84,7 @@ namespace SharpFont
 				return rec.@base;
 			}
 		}
-		
+
 		/// <summary>
 		/// Gets the stream size in bytes.
 		/// </summary>


### PR DESCRIPTION
The Face class now provides a constructor which accepts Stream as a parameter. The stream must support reading and seeking.
Callback functions for reading/seeking and closing the external stream are provided by the Face class (StreamIOFunc, StreamCloseFunc). I changed the delegates to accept IntPtr as an opaque pointer to the stream FT_Stream structure, instead of NativeReference<FTStream>.
The stream is open during the entire duration of Face existence. The user can choose whether it should be disposed together with the Face or not (using the takeStreamOwnership argument when creating Face).

The goal here is 1) to allow the user to access fonts via some custom virtual file system 2) to avoid the necessity of loading entire font into memory