### PR TITLE
Fixed StrfName's String property returning unicode strings of wrong length

### DIFF
--- a/Source/SharpFont/TrueType/SfntName.cs
+++ b/Source/SharpFont/TrueType/SfntName.cs
@@ -117,7 +117,7 @@ namespace SharpFont.TrueType
 				//TODO it may be possible to consolidate all of these properties
 				//if the strings follow some sane structure. Otherwise, leave
 				//them or add more overloads for common encodings like UTF-8.
-				return Marshal.PtrToStringUni(rec.@string, (int)rec.string_len);
+				return Marshal.PtrToStringUni(rec.@string, (int) Math.Ceiling(rec.string_len/2.0));
 			}
 		}
 


### PR DESCRIPTION
StrfName's String property uses [Marshal.PtrToStringUni](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.ptrtostringuni) to cast the recieved string to a C# string, passing it the `string_len` from the [StrfName](https://www.freetype.org/freetype2/docs/reference/ft2-sfnt_names.html#FT_SfntName) structure of FreeType. According to FreeType's documentation, `string_len` represents the length of string in bytes, while `PtrToStringUni`'s `len` parameter recieves number of Unicode characters to copy, each being 2 bytes. This results in StrfName's Strings being longer than they really are.

Tested this change on some Windows embedded fonts in Win7, and the fields now get fetched correctly.