### PR TITLE
Eliminate gray border in ToGdipBitmap

### DIFF
--- a/Source/SharpFont.GDI/FTBitmapExtensions.cs
+++ b/Source/SharpFont.GDI/FTBitmapExtensions.cs
@@ -70,7 +70,7 @@ namespace SharpFont.Gdi
 						for (int i = 0; i < palette.Entries.Length; i++)
 						{
 							float a = (i * 17) / 255f;
-							palette.Entries[i] = Color.FromArgb(i * 17, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
+							palette.Entries[i] = Color.FromArgb(i * 17, color);
 						}
 
 						bmp.Palette = palette;
@@ -91,7 +91,7 @@ namespace SharpFont.Gdi
 						for (int i = 0; i < palette.Entries.Length; i++)
 						{
 							float a = i / 255f;
-							palette.Entries[i] = Color.FromArgb(i, (int)(color.R * a), (int)(color.G * a), (int)(color.B * a));
+							palette.Entries[i] = Color.FromArgb(i, color);
 						}
 
 						//HACK There's a bug in Mono's libgdiplus requiring the "PaletteHasAlpha" flag to be set for transparency to work properly


### PR DESCRIPTION
Current implementation of ToGdipBitmap extension method (when PixelMode.Gray) keeps gray border around letters:
![image](https://user-images.githubusercontent.com/10885108/68671910-250c1b00-0559-11ea-8bad-4890a83ade30.png)

It doesn't look good when bright text is rendered on bright background.
Instead, I propose to eliminate this background and use only alpha component for antialiasing.
The PR produces following text:

![image](https://user-images.githubusercontent.com/10885108/68671926-2b01fc00-0559-11ea-8c79-5d6519cbdf92.png)

Black text on white background produces same pixels when the PR applied.
